### PR TITLE
feat: add homebrew cask formula

### DIFF
--- a/audioscrobbler.rb
+++ b/audioscrobbler.rb
@@ -1,0 +1,21 @@
+cask "audioscrobbler" do
+  version "1.3"
+  sha256 "519ec5c9bc583516ed4d86d51cdd7f4eba6d206e93d49d9d028b7d081fca6626"
+
+  url "https://github.com/heyvito/audioscrobbler/releases/download/v#{version}/Audioscrobbler.#{version}.dmg"
+  name "Audioscrobbler"
+  desc "Last.fm scrobbler for macOS Music app"
+  homepage "https://github.com/heyvito/audioscrobbler"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  app "Audioscrobbler.app"
+
+  zap trash: [
+    "~/Library/Preferences/dev.vito.Audioscrobbler.plist",
+    "~/Library/Application Support/Audioscrobbler",
+  ]
+end


### PR DESCRIPTION
Hi! I've added a Homebrew cask formula to make it easier for people to install Audioscrobbler.

The formula points to the latest release (v1.3) and includes the proper SHA256 checksum for verification.

With this, users can install the app directly using Homebrew:
```bash
brew install --cask https://raw.githubusercontent.com/heyvito/audioscrobbler/master/audioscrobbler.rb
```

If you want to get this into the official Homebrew repository, you'd just need to copy `audioscrobbler.rb` to `Casks/a/audioscrobbler.rb` in the homebrew-cask repo and open a PR there. Then people could install with just `brew install --cask audioscrobbler`.

Let me know if you'd like any changes!